### PR TITLE
chore(deps): Update Frappe version and action Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -45,7 +45,7 @@ jobs:
           build-args: |
             APPS_JSON_BASE64=${{ env.APPS_JSON_BASE64 }}
             FRAPPE_PATH=https://github.com/frappe/frappe
-            FRAPPE_BRANCH=version-14
+            FRAPPE_BRANCH=version-16
 
           tags: |
             ahuahuachi/erpnext_mexico_compliance:latest


### PR DESCRIPTION
### Summary
Updates the Frappe branch utilized in the Docker CI build to version 16 and integrates Dependabot to automatically manage GitHub Actions updates. This ensures the project aligns with the latest Frappe version and keeps CI/CD workflows secure and current.

### Type of Change
- [ ] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] perf: Performance improvement
- [ ] docs: Documentation only
- [ ] test: Adding or updating tests
- [x] chore: Build process, tooling or dependency update
- [ ] ci: CI/CD configuration
- [ ] style: Formatting, missing semi-colons, etc.
- [ ] revert: Reverts a previous commit

### Changes
*   `chore(ci)`: Updates the `FRAPPE_BRANCH` variable in the Docker CI workflow from `version-14` to `version-16`.
*   `chore(dependabot)`: Configures Dependabot to check for GitHub Actions updates weekly, improving dependency management for workflows.

### Breaking Changes
_None_.

### Related Issues


### Testing
Changes were verified by ensuring CI/CD pipelines pass successfully with the updated configurations.