### PR TITLE
ci(docker): Removes push trigger

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,8 +1,6 @@
 name: Docker Image CI
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
     branches: ["main"]
     types:


### PR DESCRIPTION
### Summary
Updates the Docker CI workflow configuration to remove the push trigger to the main branch. This change streamlines CI execution to focus solely on pull requests for the main branch, avoiding redundant runs.

### Type of Change
- [ ] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] perf: Performance improvement
- [ ] docs: Documentation only
- [ ] test: Adding or updating tests
- [ ] chore: Build process, tooling or dependency update
- [x] ci: CI/CD configuration
- [ ] style: Formatting, missing semi-colons, etc.
- [ ] revert: Reverts a previous commit

### Changes
- ci: Removes the `push` event trigger for the Docker CI workflow on the `main` branch.

### Breaking Changes
_None_.

### Related Issues


### Testing
Verified by observing that the Docker CI workflow no longer triggers on direct pushes to the `main` branch, while still running on pull requests targeting `main`.