### PR TITLE
feat(ws_client): sets custom User-Agent header

### DIFF
--- a/erpnext_mexico_compliance/ws_client/client.py
+++ b/erpnext_mexico_compliance/ws_client/client.py
@@ -2,16 +2,33 @@
 For license information, please see license.txt"""
 
 import json
+import platform
 
 import frappe
 from frappe import _
 from frappe.frappeclient import FrappeClient
+from frappe.utils import get_app_version
 from satcfdi.cfdi import CFDI
 
 from . import models
 
 
 class APIClient(FrappeClient):
+	def __init__(self, url, api_key, api_secret):
+		super().__init__(url=url, api_key=api_key, api_secret=api_secret)
+		self.__set_user_agent()
+
+	def __set_user_agent(self):
+		app_name = "erpnext_mexico_compliance"
+		app_title = frappe.get_hooks("app_title", app_name=app_name)[0]
+		app_title = app_title.replace(" ", "_")
+		version = get_app_version(app_name)
+		os_name = platform.system()
+		os_version = platform.release()
+		machine = platform.machine()
+
+		self.headers["User-Agent"] = f"{app_title}/{version} ({os_name} {os_version} {machine})"
+
 	def post_process(self, response):
 		try:
 			return super().post_process(response)


### PR DESCRIPTION
### Summary
This change introduces a custom User-Agent header for the `APIClient`, providing more detailed client information in outgoing requests. It helps the backend identify the source application, its version, and the operating system environment.

### Type of Change
- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] perf: Performance improvement
- [ ] docs: Documentation only
- [ ] test: Adding or updating tests
- [ ] chore: Build process, tooling or dependency update
- [ ] ci: CI/CD configuration
- [ ] style: Formatting, missing semi-colons, etc.
- [ ] revert: Reverts a previous commit

### Changes
- `feat(ws_client)`: Adds a custom `User-Agent` header to outgoing requests made by the `APIClient`. This header includes the application name, version, operating system, and machine architecture for improved client identification.

### Breaking Changes
_None_

### Related Issues

### Testing
The new User-Agent header functionality can be tested by making a request through the `APIClient` and inspecting the outgoing request headers to ensure the User-Agent string is correctly formatted and included.