### PR TITLE
feat(sales-invoice): Add SAT UOM Key validation

### DIFF
--- a/erpnext_mexico_compliance/overrides/sales_invoice_item.py
+++ b/erpnext_mexico_compliance/overrides/sales_invoice_item.py
@@ -3,15 +3,18 @@ Copyright (c) 2022-2025, TI Sin Problemas and contributors
 For license information, please see license.txt
 """
 
+import typing as t
 from decimal import Decimal
 
 import frappe
 from erpnext.accounts.doctype.sales_invoice_item import sales_invoice_item
 from erpnext.setup.doctype.uom.uom import UOM
-from erpnext.stock.doctype.item.item import Item
 from frappe import _
 from frappe.utils import strip_html
 from satcfdi.create.cfd import catalogos, cfdi40
+
+if t.TYPE_CHECKING:
+	from erpnext.stock.doctype.item.item import Item
 
 
 class SalesInvoiceItem(sales_invoice_item.SalesInvoiceItem):
@@ -43,19 +46,18 @@ class SalesInvoiceItem(sales_invoice_item.SalesInvoiceItem):
 				)
 			)
 
-		if not self.uom_doc.mx_uom_key:
+		if self.uom_doc and not self.uom_doc.mx_uom_key:  # type: ignore
 			frappe.throw(_("UOM {0} at row {1} does not have a SAT UOM Key").format(self.uom, self.idx))
 
 	@property
-	def item_doc(self) -> Item:
+	def item_doc(self) -> Item | None:
 		"""Related Item DocType
 
 		Returns:
 			Item: Item doctype
 		"""
 		if self.item_code:
-			return frappe.get_doc("Item", self.item_code)
-		return None
+			return frappe.get_doc("Item", self.item_code)  # type: ignore
 
 	@property
 	def uom_doc(self) -> UOM:
@@ -64,7 +66,7 @@ class SalesInvoiceItem(sales_invoice_item.SalesInvoiceItem):
 		Returns:
 			UOM: UOM of the item
 		"""
-		return frappe.get_doc("UOM", self.uom)
+		return frappe.get_doc("UOM", self.uom)  # type: ignore
 
 	@property
 	def service_duration_display(self) -> str:

--- a/erpnext_mexico_compliance/overrides/sales_invoice_item.py
+++ b/erpnext_mexico_compliance/overrides/sales_invoice_item.py
@@ -33,7 +33,7 @@ class SalesInvoiceItem(sales_invoice_item.SalesInvoiceItem):
 				self.db_update()
 
 	def validate(self):
-		"""Checks if the item has a SAT Product or Service Key."""
+		"""Checks if the item has a SAT Product or Service Key and SAT UOM Key."""
 		self.before_validate()
 
 		if not self.mx_product_service_key:
@@ -43,12 +43,15 @@ class SalesInvoiceItem(sales_invoice_item.SalesInvoiceItem):
 				)
 			)
 
+		if not self.uom_doc.mx_uom_key:
+			frappe.throw(_("UOM {0} at row {1} does not have a SAT UOM Key").format(self.uom, self.idx))
+
 	@property
 	def item_doc(self) -> Item:
 		"""Related Item DocType
 
 		Returns:
-		    Item: Item doctype
+			Item: Item doctype
 		"""
 		if self.item_code:
 			return frappe.get_doc("Item", self.item_code)
@@ -59,7 +62,7 @@ class SalesInvoiceItem(sales_invoice_item.SalesInvoiceItem):
 		"""The UOM (Unit of Measure) DocType of the item.
 
 		Returns:
-		    UOM: UOM of the item
+			UOM: UOM of the item
 		"""
 		return frappe.get_doc("UOM", self.uom)
 
@@ -77,7 +80,7 @@ class SalesInvoiceItem(sales_invoice_item.SalesInvoiceItem):
 		- From `start_date` To `end_date`
 
 		Returns:
-		    str: The formatted service duration string.
+			str: The formatted service duration string.
 		"""
 		start_date = ""
 		if self.service_start_date:


### PR DESCRIPTION
### Summary
Introduces a new validation within Sales Invoice Items to ensure that the Unit of Measure (UOM) has an associated SAT UOM Key. This change also includes improvements to type safety and handling of potentially null values for related document properties.

### Type of Change
- [x] feat: New feature
- [ ] fix: Bug fix
- [x] refactor: Code refactor (no functional change)
- [ ] perf: Performance improvement
- [ ] docs: Documentation only
- [ ] test: Adding or updating tests
- [ ] chore: Build process, tooling or dependency update
- [ ] ci: CI/CD configuration
- [ ] style: Formatting, missing semi-colons, etc.
- [ ] revert: Reverts a previous commit

### Changes
*   `feat(sales-invoice):` Adds validation during `SalesInvoiceItem`'s `validate` lifecycle hook to ensure that the associated UOM has a `mx_uom_key` field populated.
*   `refactor(sales-invoice-item):` Improves type safety by introducing `typing` module, conditionally importing `Item`, and refining type hints for `item_doc` and `uom_doc` properties to better reflect potential `None` returns.

### Breaking Changes
_None_.

### Related Issues

### Testing
Manual testing was performed by creating Sales Invoices with items linked to UOMs both with and without the required SAT UOM Key to verify the new validation logic. Type hint improvements were verified by static analysis.