### PR TITLE
fix(email): Improves template and recipient logic

### DIFF
--- a/erpnext_mexico_compliance/controllers/common.py
+++ b/erpnext_mexico_compliance/controllers/common.py
@@ -344,7 +344,10 @@ class CommonController(Document):
 					frappe.throw(_("Invalid email contact type: {}").format(settings.send_email_to))
 
 			if not recipients:
-				frappe.throw(_("No recipients found for the current document."))
+				frappe.msgprint(
+					_("No recipients found for the current document."), indicator="yellow", alert=True
+				)
+				return
 
 			email = settings.get_email_template(self.doctype, self.as_dict())  # type: ignore
 

--- a/erpnext_mexico_compliance/erpnext_mexico_compliance/doctype/cfdi_stamping_settings/cfdi_stamping_settings.py
+++ b/erpnext_mexico_compliance/erpnext_mexico_compliance/doctype/cfdi_stamping_settings/cfdi_stamping_settings.py
@@ -198,7 +198,7 @@ class CFDIStampingSettings(Document):
 				- message: The HTML content of the email
 		"""
 		template = next(t for t in self.email_templates if t.document_type == doctype)
-		return get_email_template(template, doc)
+		return get_email_template(template.email_template, doc)
 
 
 @redis_cache(ttl=43200)  # Cache for 12 hours


### PR DESCRIPTION
### Summary
This pull request improves the email sending functionality by correcting how email templates are retrieved and by handling the absence of recipients more gracefully.

### Type of Change
- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code refactor (no functional change)
- [ ] perf: Performance improvement
- [ ] docs: Documentation only
- [ ] test: Adding or updating tests
- [ ] chore: Build process, tooling or dependency update
- [ ] ci: CI/CD configuration
- [ ] style: Formatting, missing semi-colons, etc.
- [ ] revert: Reverts a previous commit

### Changes
*   `fix:` Updates the email template retrieval logic to correctly pass the `email_template` attribute, ensuring the intended email content is used.
*   `fix:` Modifies the behavior when no email recipients are found, changing it from throwing an error to displaying a non-blocking warning message (`frappe.msgprint`) and gracefully exiting the email sending process.

### Breaking Changes
_None_.

### Related Issues


### Testing
Tested locally by configuring email settings, sending emails with various document types, and verifying correct template usage and recipient handling, including scenarios with no defined recipients.