### PR TITLE
ci: add version bump workflow and pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+<type>(<scope>): <short summary>
+
+## Summary
+
+One or two sentences describing WHAT changed and WHY (not HOW).
+
+## Type of Change
+
+- [ ] feat: New feature
+- [ ] fix: Bug fix
+- [ ] refactor: Code refactor (no functional change)
+- [ ] perf: Performance improvement
+- [ ] docs: Documentation only
+- [ ] test: Adding or updating tests
+- [ ] chore: Build process, tooling or dependency update
+- [ ] ci: CI/CD configuration
+- [ ] style: Formatting, missing semi-colons, etc.
+- [ ] revert: Reverts a previous commit
+
+## Changes
+
+List the specific changes as bullet points. Each bullet should reference the conventional commit type from the included commits.
+
+## Breaking Changes
+
+_None._
+
+## Related Issues
+
+## Testing
+
+Briefly describe how the changes were tested or what tests were added.

--- a/.github/workflows/bump-version-on-release.yml
+++ b/.github/workflows/bump-version-on-release.yml
@@ -1,0 +1,58 @@
+name: Bump version on release
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag (e.g. v0.13.4)"
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: version-16
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${{ github.event.release.tag_name || inputs.tag }}"
+          VERSION="${TAG#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Merge main into version-16
+        run: |
+          git fetch origin main
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git merge origin/main --no-edit || {
+            echo "Merge conflict detected. Resolve manually on version-16 branch."
+            exit 1
+          }
+
+      - name: Update __init__.py
+        run: |
+          sed -i 's/^__version__ = ".*"$/__version__ = "${{ steps.version.outputs.version }}"/' \
+            erpnext_mexico_compliance/__init__.py
+
+      - name: Commit and push
+        run: |
+          git add erpnext_mexico_compliance/__init__.py
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          git commit -m "chore: bump version to ${{ steps.version.outputs.version }}"
+          git push


### PR DESCRIPTION
## Summary

Add automated release tooling: a GitHub Actions workflow that bumps the app version on release publish, and a pull request template to standardize PR descriptions across the project.

## Type of Change

- [x] ci: CI/CD configuration

## Changes

- **chore(release):** Add `bump-version-on-release.yml` workflow that updates `__init__.py` with the release version when a GitHub Release is published (or manually triggered via `workflow_dispatch`)
- **chore(github):** Add `pull_request_template.md` with sections for Summary, Type of Change, Changes, Breaking Changes, Related Issues, and Testing

## Breaking Changes

_None._

## Related Issues

_None._

## Testing

The version bump workflow was tested by verifying the sed pattern, merge, and commit/push logic end-to-end in a dry run. The PR template is a documentation change and requires no automated tests.