### PR TITLE
fix(cfdi): wrap numeric values in str for Decimal precision

### DIFF
--- a/erpnext_mexico_compliance/overrides/sales_invoice.py
+++ b/erpnext_mexico_compliance/overrides/sales_invoice.py
@@ -235,6 +235,8 @@ class SalesInvoice(CommonController, sales_invoice.SalesInvoice):
 		for rsi in self.mx_related_sales_invoices:
 			related_documents.setdefault(rsi.sat_relationship_type, []).append(rsi.uuid)
 
+		conversion_rate = Decimal(str(self.conversion_rate)) if self.currency != "MXN" else None
+
 		return cfdi40.Comprobante(
 			emisor=csd.get_issuer(),
 			lugar_expedicion=address.pincode,
@@ -245,7 +247,7 @@ class SalesInvoice(CommonController, sales_invoice.SalesInvoice):
 			serie=self.cfdi_series,
 			folio=self.cfdi_folio,
 			forma_pago=self.mx_payment_mode,
-			tipo_cambio=(Decimal(self.conversion_rate) if self.currency != "MXN" else None),
+			tipo_cambio=conversion_rate,
 			metodo_pago=self.mx_payment_option,
 			fecha=self.posting_datetime,
 			cfdi_relacionados=[cfdi40.CfdiRelacionados(k, v) for k, v in related_documents.items()],

--- a/erpnext_mexico_compliance/overrides/sales_invoice_item.py
+++ b/erpnext_mexico_compliance/overrides/sales_invoice_item.py
@@ -119,7 +119,7 @@ class SalesInvoiceItem(sales_invoice_item.SalesInvoiceItem):
 				anchor = f'<a href="/app/account/{account_name}">{account_name}</a>'
 				frappe.throw(_("Account {} does not have a tax type.").format(anchor))
 			tax_type = catalogos.Impuesto[account["tax_type"]]
-			tax_rate = Decimal(account["tax_rate"]) / 100
+			tax_rate = Decimal(str(account["tax_rate"])) / 100
 			tax_rate = tax_rate.quantize(Decimal("1.000000"))
 
 			if tax_rate < 0:


### PR DESCRIPTION
### Summary
Fix decimal precision errors in CFDI XML generation by wrapping `conversion_rate` and `tax_rate` in `str()` before passing to `Decimal()`, preventing floating-point representation issues.

### Type of Change
- fix: Bug fix

### Changes
- fix(cfdi): wrap `conversion_rate` in `str()` before `Decimal()` conversion in Sales Invoice CFDI generation
- fix(cfdi): wrap `tax_rate` in `str()` before `Decimal()` conversion in Sales Invoice Item CFDI generation

### Breaking Changes
_None_

### Testing
Tested by generating CFDI XML with invoices containing decimal conversion rates and tax rates that previously caused precision errors.