### PR TITLE
fix(migration): reduce memory usage in CFDI status update migration

### DIFF
--- a/erpnext_mexico_compliance/controllers/common.py
+++ b/erpnext_mexico_compliance/controllers/common.py
@@ -166,7 +166,12 @@ class CommonController(Document):
 			Document: The result of the cancel operation if the CFDI is cancelled.
 		"""
 		ws = get_ws_client()
-		status = ws.get_status(self.mx_cfdi_obj)
+		status = ws.get_status(
+			uuid=self.mx_cfdi_obj["Complemento"]["TimbreFiscalDigital"]["UUID"],
+			issuer_rfc=self.mx_cfdi_obj["Emisor"]["Rfc"],
+			receiver_rfc=self.mx_cfdi_obj["Receptor"]["Rfc"],
+			total=self.mx_cfdi_obj["Total"],
+		)
 		if status.is_cancellable == status.CancellableStatus.NOT_CANCELLABLE:
 			self.mx_is_cancellable = 0
 			self.mx_cfdi_status = CFDIStatus.VALID.value
@@ -190,7 +195,12 @@ class CommonController(Document):
 			Document: The result of the cancel operation if the CFDI is cancelled.
 		"""
 		client = get_ws_client()
-		status = client.get_status(CFDI.from_string(self.mx_stamped_xml.encode("utf-8")))
+		status = client.get_status(
+			uuid=self.mx_cfdi_obj["Complemento"]["TimbreFiscalDigital"]["UUID"],
+			issuer_rfc=self.mx_cfdi_obj["Emisor"]["Rfc"],
+			receiver_rfc=self.mx_cfdi_obj["Receptor"]["Rfc"],
+			total=self.mx_cfdi_obj["Total"],
+		)
 		title = status.status if isinstance(status.status, str) else status.status.value
 		is_cancellable = status.is_cancellable.value if status.is_cancellable else None
 		cancellation_status = status.cancellation_status.value if status.cancellation_status else None

--- a/erpnext_mexico_compliance/migrate/after_migrate.py
+++ b/erpnext_mexico_compliance/migrate/after_migrate.py
@@ -1,3 +1,4 @@
+import gc
 import typing as t
 
 import click
@@ -66,8 +67,8 @@ def _set_missing_cfdi_status(doctype: t.Literal["Sales Invoice", "Payment Entry"
 		while True:
 			docs = frappe.get_all(
 				doctype,
-				fields=["name", "mx_stamped_xml", "cancellation_acknowledgement"],
 				filters={"mx_cfdi_status": ["is", "not set"], "mx_stamped_xml": ["is", "set"]},
+				pluck="name",
 				order_by="name",
 				limit=CHUNK_SIZE,
 			)
@@ -75,9 +76,11 @@ def _set_missing_cfdi_status(doctype: t.Literal["Sales Invoice", "Payment Entry"
 			if not docs:
 				break
 
-			for idx, doc in enumerate(docs):
-				ack = doc["cancellation_acknowledgement"]
-				cfdi: CFDI = CFDI.from_string(doc.mx_stamped_xml.encode("utf-8"))  # type: ignore
+			for idx, name in enumerate(docs):
+				mx_stamped_xml, ack = frappe.get_value(
+					doctype, name, ["mx_stamped_xml", "cancellation_acknowledgement"]
+				)
+				cfdi: CFDI = CFDI.from_string(mx_stamped_xml.encode("utf-8"))  # type: ignore
 
 				if test_mode:
 					status = models.CfdiStatus.DocumentStatus.ACTIVE
@@ -102,14 +105,17 @@ def _set_missing_cfdi_status(doctype: t.Literal["Sales Invoice", "Payment Entry"
 					value = CFDIStatus.VALID.value
 
 				else:
-					frappe.log_error(f"Failed to set CFDI status for {doctype} {doc.name}")
+					frappe.log_error(f"Failed to set CFDI status for {doctype} {name}")
 					continue
 
-				frappe.db.set_value(doctype, doc.name, "mx_cfdi_status", value)
+				frappe.db.set_value(doctype, name, "mx_cfdi_status", value)
 
 				update_progress_bar(f"Setting {doctype} missing CFDI Status", idx, len(docs))
+				del cfdi
 
 			frappe.db.commit()
+			gc.collect()
+
 	except JobTimeoutException as e:
 		frappe.log_error(
 			title=f"JobTimeoutException in _set_missing_cfdi_status for {doctype}",

--- a/erpnext_mexico_compliance/migrate/after_migrate.py
+++ b/erpnext_mexico_compliance/migrate/after_migrate.py
@@ -83,7 +83,12 @@ def _set_missing_cfdi_status(doctype: t.Literal["Sales Invoice", "Payment Entry"
 					status = models.CfdiStatus.DocumentStatus.ACTIVE
 				else:
 					try:
-						status = api.get_status(cfdi).status
+						status = api.get_status(
+							uuid=cfdi["Complemento"]["TimbreFiscalDigital"]["UUID"],
+							issuer_rfc=cfdi["Emisor"]["Rfc"],
+							receiver_rfc=cfdi["Receptor"]["Rfc"],
+							total=cfdi["Total"],
+						).status
 					except Exception:
 						status = models.CfdiStatus.DocumentStatus.ACTIVE
 

--- a/erpnext_mexico_compliance/ws_client/client.py
+++ b/erpnext_mexico_compliance/ws_client/client.py
@@ -123,20 +123,20 @@ class APIClient(FrappeClient):
 		"""
 		return self.get_api("tisp_apps.api.v1.cfdi.subscription_details")
 
-	def get_status(self, cfdi: CFDI):
+	def get_status(
+		self, *, uuid: str, issuer_rfc: str, receiver_rfc: str, total: float | str
+	) -> models.CfdiStatus:
 		"""Retrieves the status of a CFDI from the CFDI Web Service.
 
 		Args:
-			cfdi (CFDI): The CFDI to retrieve the status of.
+			uuid (str): The UUID of the CFDI.
+			issuer_rfc (str): The RFC of the issuer of the CFDI.
+			receiver_rfc (str): The RFC of the receiver of the CFDI.
+			total (float | str): The total amount of the CFDI.
 
 		Returns:
-			dict: The API response containing the status of the CFDI.
+			CfdiStatus: The API response containing the status of the CFDI.
 		"""
-		params = {
-			"uuid": cfdi["Complemento"]["TimbreFiscalDigital"]["UUID"],
-			"issuer_rfc": cfdi["Emisor"]["Rfc"],
-			"receiver_rfc": cfdi["Receptor"]["Rfc"],
-			"total": cfdi["Total"],
-		}
+		params = {"uuid": uuid, "issuer_rfc": issuer_rfc, "receiver_rfc": receiver_rfc, "total": total}
 		response = self.get_api("tisp_apps.api.v1.cfdi.status", params=params)
 		return models.CfdiStatus.from_dict(response)


### PR DESCRIPTION
### Summary

Refactor the `get_status` API to accept explicit CFDI parameters instead of the full CFDI object, and fix a memory leak in the `_set_missing_cfdi_status` migration that caused excessive memory usage when processing large batches of invoices.

### Type of Change

- fix: Bug fix
- refactor: Code refactor (no functional change)

### Changes

- **refactor(cfdi):** Change `APIClient.get_status` to accept explicit keyword-only parameters (`uuid`, `issuer_rfc`, `receiver_rfc`, `total`) instead of the entire CFDI object, improving clarity and decoupling the API client from CFDI parsing
- **refactor(cfdi):** Update `CommonController._check_cfdi_status` and `_cancel_cfdi` to pass explicit parameters to `get_status`
- **fix(migration):** Avoid loading full `mx_stamped_xml` and `cancellation_acknowledgement` into memory for all documents at once by fetching only `name` first, then retrieving XML per-document
- **fix(migration):** Add explicit `del cfdi` and `gc.collect()` calls after processing each document/chunk to free memory
- **fix(migration):** Update `_set_missing_cfdi_status` to use the new explicit-parameter `get_status` API

### Breaking Changes

_None_

### Related Issues

None identified.

### Testing

- Ran `_set_missing_cfdi_status` migration against a site with a large number of unprocessed invoices and confirmed reduced memory footprint and no `JobTimeoutException`
- Verified `get_status` still returns correct `CfdiStatus` responses with explicit parameters