### PR TITLE
feat(exchange_rate): Integrate Banxico SIE API for USD/MXN selling rate

### DIFF
--- a/erpnext_mexico_compliance/banxico/__init__.py
+++ b/erpnext_mexico_compliance/banxico/__init__.py
@@ -1,0 +1,13 @@
+import frappe
+
+from erpnext_mexico_compliance.erpnext_mexico_compliance.doctype.cfdi_stamping_settings.cfdi_stamping_settings import (
+	CFDIStampingSettings,
+)
+
+from .client import SIEClient
+
+
+def get_sie_client() -> SIEClient:
+	settings: CFDIStampingSettings = frappe.get_single("CFDI Stamping Settings")  # type: ignore
+	token = settings.get_sie_api_token()
+	return SIEClient(token)  # type: ignore

--- a/erpnext_mexico_compliance/banxico/client.py
+++ b/erpnext_mexico_compliance/banxico/client.py
@@ -1,0 +1,9 @@
+"""Copyright (c) 2026, TI Sin Problemas and contributors
+For license information, please see license.txt"""
+
+from .sectors.exchange_rates import DailyExchangeRates
+
+
+class SIEClient:
+	def __init__(self, token: str):
+		self.daily_exchange_rates = DailyExchangeRates(token)

--- a/erpnext_mexico_compliance/banxico/sectors/base.py
+++ b/erpnext_mexico_compliance/banxico/sectors/base.py
@@ -1,0 +1,18 @@
+"""Copyright (c) 2026, TI Sin Problemas and contributors
+For license information, please see license.txt"""
+
+import requests
+
+
+class BaseSector:
+	base_url = "https://www.banxico.org.mx/SieAPIRest/service/v1/series"
+
+	def __init__(self, token: str):
+		self.token = token
+		self.session = requests.Session()
+		self.session.headers.update({"Bmx-Token": token, "Accept": "application/json"})
+
+	def get(self, url: str) -> dict:
+		self.response = self.session.get(url)
+		self.response.raise_for_status()
+		return self.response.json()

--- a/erpnext_mexico_compliance/banxico/sectors/exchange_rates.py
+++ b/erpnext_mexico_compliance/banxico/sectors/exchange_rates.py
@@ -1,0 +1,44 @@
+"""Copyright (c) 2026, TI Sin Problemas and contributors
+For license information, please see license.txt"""
+
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+from .base import BaseSector
+
+
+class DailyExchangeRates(BaseSector):
+	DATE_OF_SETTLEMENT_SERIES = "SF60653"
+	DATE_OF_DETERMINATION_SERIES = "SF43718"
+
+	def to_settle_liabilities_metadata(self) -> dict:
+		response = self.session.get(f"{self.base_url}/{self.DATE_OF_SETTLEMENT_SERIES}")
+		data = response.json()
+		bmx = data["bmx"]
+		series = bmx["series"]
+
+		return series[0]
+
+	def to_settle_liabilities_data(
+		self, start_date: date | None = None, end_date: date | None = None
+	) -> list:
+		if not start_date:
+			start_date = datetime.now(tz=ZoneInfo("America/Mexico_City")).date()
+
+		if not end_date:
+			end_date = datetime.now(tz=ZoneInfo("America/Mexico_City")).date()
+
+		formatted_start_date = start_date.strftime("%Y-%m-%d")
+		formatted_end_date = end_date.strftime("%Y-%m-%d")
+
+		url = f"{self.base_url}/{self.DATE_OF_SETTLEMENT_SERIES}/datos"
+		url = f"{url}/{formatted_start_date}/{formatted_end_date}"
+
+		data = self.get(url)
+		bmx = data["bmx"]
+		series = bmx["series"]
+
+		return series[0]["datos"]
+
+
+pass

--- a/erpnext_mexico_compliance/erpnext_mexico_compliance/doctype/cfdi_stamping_settings/cfdi_stamping_settings.json
+++ b/erpnext_mexico_compliance/erpnext_mexico_compliance/doctype/cfdi_stamping_settings/cfdi_stamping_settings.json
@@ -6,6 +6,7 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "cfdi_tab",
   "web_service_section",
   "api_key",
   "api_secret",
@@ -21,7 +22,9 @@
   "column_break_twmd",
   "send_email_on_stamp",
   "send_email_to",
-  "email_templates"
+  "email_templates",
+  "currency_exchange_tab",
+  "sie_api_token"
  ],
  "fields": [
   {
@@ -124,13 +127,29 @@
    "label": "Email Templates",
    "mandatory_depends_on": "eval: doc.send_email_on_stamp && doc.is_premium",
    "options": "CFDI Email Template"
+  },
+  {
+   "fieldname": "cfdi_tab",
+   "fieldtype": "Tab Break",
+   "label": "CFDI"
+  },
+  {
+   "fieldname": "currency_exchange_tab",
+   "fieldtype": "Tab Break",
+   "label": "Currency Exchange"
+  },
+  {
+   "description": "The query token required to use Banxico's SIE API. You can obtain a token on the following URL: https://www.banxico.org.mx/SieAPIRest/service/v1/token",
+   "fieldname": "sie_api_token",
+   "fieldtype": "Password",
+   "label": "SIE API Token"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-06-25 03:49:24.909084",
+ "modified": "2026-07-18 22:35:59.396208",
  "modified_by": "Administrator",
  "module": "ERPNext Mexico Compliance",
  "name": "CFDI Stamping Settings",

--- a/erpnext_mexico_compliance/erpnext_mexico_compliance/doctype/cfdi_stamping_settings/cfdi_stamping_settings.py
+++ b/erpnext_mexico_compliance/erpnext_mexico_compliance/doctype/cfdi_stamping_settings/cfdi_stamping_settings.py
@@ -49,6 +49,7 @@ class CFDIStampingSettings(Document):
 		pdf_templates: DF.Table[CFDIPDFTemplate]
 		send_email_on_stamp: DF.Check
 		send_email_to: DF.Literal["", "All Billing Contacts", "Document Contact"]
+		sie_api_token: DF.Password | None
 		stamp_on_submit: DF.Check
 		test_mode: DF.Check
 	# end: auto-generated types
@@ -199,6 +200,14 @@ class CFDIStampingSettings(Document):
 		"""
 		template = next(t for t in self.email_templates if t.document_type == doctype)
 		return get_email_template(template.email_template, doc)
+
+	def get_sie_api_token(self):
+		"""Returns the API token for the Banxico SIE API.
+
+		Returns:
+			str: The API token.
+		"""
+		return self.get_password("sie_api_token")
 
 
 @redis_cache(ttl=43200)  # Cache for 12 hours

--- a/erpnext_mexico_compliance/hooks.py
+++ b/erpnext_mexico_compliance/hooks.py
@@ -185,9 +185,9 @@ scheduler_events = {
 # Overriding Methods
 # ------------------------------
 #
-# override_whitelisted_methods = {
-# 	"frappe.desk.doctype.event.event.get_events": "erpnext_mexico_compliance.event.get_events"
-# }
+override_whitelisted_methods = {
+	"erpnext.setup.utils.get_exchange_rate": "erpnext_mexico_compliance.utils.exchange_rates.get_exchange_rate"
+}
 #
 # each overriding function accepts a `data` argument;
 # generated from the base implementation of the doctype dashboard,

--- a/erpnext_mexico_compliance/utils/exchange_rates.py
+++ b/erpnext_mexico_compliance/utils/exchange_rates.py
@@ -1,0 +1,15 @@
+import frappe
+from erpnext.setup.utils import get_exchange_rate as erpnext_get_exchange_rate
+from frappe.utils import getdate
+
+from erpnext_mexico_compliance.banxico import get_sie_client
+
+
+@frappe.whitelist()
+def get_exchange_rate(from_currency, to_currency, transaction_date=None, args=None):
+	if args == "for_selling" and from_currency == "USD" and to_currency == "MXN":
+		sie = get_sie_client()
+		date = getdate(transaction_date)
+		data = sie.daily_exchange_rates.to_settle_liabilities_data(start_date=date, end_date=date)
+		return data[0]["dato"]
+	return erpnext_get_exchange_rate(from_currency, to_currency, transaction_date, args)

--- a/erpnext_mexico_compliance/utils/exchange_rates.py
+++ b/erpnext_mexico_compliance/utils/exchange_rates.py
@@ -1,12 +1,17 @@
 import frappe
 from erpnext.setup.utils import get_exchange_rate as erpnext_get_exchange_rate
-from frappe.utils import getdate
+from frappe.utils import DateTimeLikeObject, getdate
 
 from erpnext_mexico_compliance.banxico import get_sie_client
 
 
 @frappe.whitelist()
-def get_exchange_rate(from_currency, to_currency, transaction_date=None, args=None):
+def get_exchange_rate(
+	from_currency: str,
+	to_currency: str,
+	transaction_date: DateTimeLikeObject | None = None,
+	args: str | None = None,
+):
 	if args == "for_selling" and from_currency == "USD" and to_currency == "MXN":
 		sie = get_sie_client()
 		date = getdate(transaction_date)


### PR DESCRIPTION
### Summary

Integrate Banxico's SIE REST API to fetch official USD/MXN exchange rates for selling operations, overriding ERPNext's default exchange rate lookup with authoritative data from the Mexican central bank.

### Type of Change

- feat: New feature

### Changes

- **feat(banxico):** Add new `banxico` module with SIE API client (`SIEClient`) and sector-based architecture for API requests
- **feat(exchange_rate):** Override ERPNext's `get_exchange_rate` whitelisted method to use Banxico's daily exchange rate data (series SF60653) for USD→MXN selling conversions
- **feat(cfdi_stamping_settings):** Add `SIE API Token` password field and "Currency Exchange" tab to the CFDI Stamping Settings doctype
- **chore(hooks):** Register `get_exchange_rate` override in `override_whitelisted_methods`

### Breaking Changes

_None_.

### Related Issues

_None_.

### Testing

- Verified the Banxico SIE API client initializes correctly with a token from settings
- Confirmed the exchange rate override returns Banxico data for USD→MXN and falls back to ERPNext for all other currency pairs